### PR TITLE
feat: implement profile-based security system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,16 @@ npm run build && node dist/index.js install --project-local # Install to project
 - **Destructive-only blocking** - Only blocks genuinely harmful operations (rm -rf /, system wipes)
 - **Developer trust** - Assumes most operations are legitimate development work
 
+### Customization: Disabling Auto-Approval for Write Operations
+
+By default, CCB fast-approves file write operations (Write, Edit, MultiEdit, NotebookEdit) for developer productivity. To require AI approval for all write operations:
+
+1. Edit `src/commands/auto-approve-tools.ts`
+2. Comment out the `SAFE_WRITE_TOOLS` set and the corresponding logic in `shouldFastApprove()`
+3. Rebuild with `npm run build`
+
+This ensures all write operations go through AI analysis for approval, providing an extra layer of security at the cost of some convenience. The code includes clear comments showing how to re-enable fast approval for write operations if needed.
+
 ### Testing Strategy
 - Unit tests for approval logic
 - Integration tests with actual Claude API calls

--- a/docs/review-todos/profile-security-system.md
+++ b/docs/review-todos/profile-security-system.md
@@ -1,0 +1,167 @@
+# Improvements and Recommendations — Profile-Based Security System (PR #2)
+
+This document summarizes recommended improvements to the new profile-based security system (strict, default, permissive), the `set-profile` command, config/schema updates, and fast-approval logic.
+
+## Summary
+
+- Positive: Profiles provide clear risk tiers; default posture is cautious; profile-scoped prompts are a good foundation.
+- Focus Areas:
+  - Make the policy explicit and testable.
+  - Fail-closed behavior for unknown ops and config errors.
+  - Strong config validation, schema versioning, and migration.
+  - Mandatory confirmations for destructive or high-impact operations.
+  - Auditing, logging, and test coverage across the profile matrix.
+  - UX safeguards for `set-profile`, especially in CI/non-interactive contexts.
+  - Prompt template hardening and runtime error handling.
+
+---
+
+## 1) Policy Model and Guarantees
+
+- Publish an explicit operation-policy matrix for each profile (and enforce it in code).
+- Fail-closed: Unknown operations or missing policy entries should require confirmation.
+- Always require confirmation (across all profiles) for destructive/high-impact operations:
+  - File deletions or overwrites outside staged changes
+  - Shell execution and network calls
+  - Git pushes, dependency installs, credential/secrets access
+- Provide time-bounded “fast approval” and require justification for elevated actions.
+- Add a global “dry-run” mode to preview changes without writes.
+- Add per-operation overrides (e.g., `--confirm-once`, `--no-write`) that cannot silently downgrade safeguards.
+
+### Recommended Matrix to Document (example)
+| Operation                       | strict        | default       | permissive    |
+|---------------------------------|---------------|---------------|---------------|
+| Read-only actions               | auto-allow    | auto-allow    | auto-allow    |
+| Write within workspace          | confirm       | confirm       | auto-allow    |
+| Delete/overwrite files          | confirm       | confirm       | confirm       |
+| Run shell commands              | confirm       | confirm       | confirm       |
+| Network requests                | confirm       | confirm       | confirm       |
+| Git commit                      | confirm       | confirm       | auto-allow    |
+| Git push                        | confirm       | confirm       | confirm       |
+| Dependency install/update       | confirm       | confirm       | confirm       |
+| Access secrets/credentials      | confirm       | confirm       | confirm       |
+
+Note: Even in “permissive”, keep confirmations for destructive/high-risk areas.
+
+---
+
+## 2) Config and Schema
+
+- Add schema versioning (e.g., `schemaVersion`) and explicit migration steps.
+- Validate configuration strictly with clear error messages; fail-closed on errors.
+- Define precedence: CLI flags > env vars > repo config > global config.
+- Support per-repo overrides while allowing a global default profile.
+- Prevent silent profile downgrades via scripts; require TTY or explicit `--force` for permissive.
+- Provide `config.example.yml` and document all fields with defaults.
+
+Example (to include in docs/examples):
+```yaml
+schemaVersion: 1
+profile: default  # strict | default | permissive
+fastApproval:
+  enabled: true
+  ttlSeconds: 600
+  requireJustification: true
+ci:
+  enforceStrictProfile: true
+  allowPermissive: false
+logging:
+  level: info
+  auditFile: .logs/security-audit.log
+```
+
+---
+
+## 3) `set-profile` Command UX
+
+- Show a summary/diff of what changes when switching profiles; require confirmation.
+- Persist profile selection clearly (and show where it’s stored).
+- Disallow switching to permissive in non-interactive contexts unless `--force` is given.
+- Provide `--show` to print current profile and effective policy.
+- Add shell completions and thoughtful error messages.
+
+---
+
+## 4) Fast Approval Logic
+
+- Centralize fast-approval gating in a single module to avoid bypasses.
+- Require justification for elevated approvals; log who/when/why with TTL.
+- Add rate limiting/cooldown to prevent approval storms.
+- Ensure expirations are enforced and visible in the audit log.
+
+---
+
+## 5) Logging and Auditability
+
+- Structured logs with: timestamp, user, repo, profile, operation, path(s), result (allowed/blocked/confirmed), justification.
+- Redact secrets and sensitive paths.
+- Provide a lightweight `audit` subcommand to view and filter recent security events.
+- Document retention and rotation recommendations.
+
+---
+
+## 6) Testing Strategy
+
+- Unit tests:
+  - Operation-policy matrix for each profile (table-driven).
+  - Fail-closed behavior on unknown ops and invalid configs.
+  - Fast-approval TTL and justification requirements.
+- Integration/E2E:
+  - CLI interactions for `set-profile` including non-interactive modes.
+  - CI mode defaults (strict) and override guards.
+  - Regression tests for destructive action confirmations.
+- Snapshot tests for prompt templates per profile.
+- Concurrency/parallel execution tests to ensure a single source of truth.
+
+---
+
+## 7) Prompt Templates (Security Hardening)
+
+- Validate and sanitize all template variables; avoid injecting untrusted content verbatim.
+- Include explicit guardrails in prompts clarifying the active profile and allowed actions.
+- Provide fallback behavior if a profile template is missing; fail-closed with a clear message.
+- Document how to extend or customize prompts safely.
+
+---
+
+## 8) CI/CD and Non-Interactive Environments
+
+- Default to `strict` in CI, regardless of repo config, unless explicitly overridden.
+- Forbid permissive in CI without `--force` and a clear, logged justification.
+- Ensure exit codes reflect blocked actions to fail pipelines fast.
+- Document recommended CI configuration snippets.
+
+---
+
+## 9) Documentation
+
+- Add a quickstart for profiles with decision guidance (when to use which).
+- Include the full operation-policy matrix, threat model assumptions, and trust boundaries.
+- Migration notes for existing users (breaking changes and safe upgrades).
+- Troubleshooting for common validation errors and non-interactive edge cases.
+
+---
+
+## 10) Implementation Notes
+
+- Separate policy evaluation, config loading, and I/O execution.
+- Use a typed schema and central config loader; avoid scattered conditionals.
+- Single source of truth for “current profile” and effective policy.
+- Consistent error handling strategy with actionable messages.
+
+---
+
+## Acceptance Checklist
+
+- [ ] Operation-policy matrix implemented and documented; unknown ops fail-closed.
+- [ ] Destructive/high-impact ops require confirmation in all profiles.
+- [ ] Schema versioning, strict validation, and migration path in place.
+- [ ] `set-profile` has confirmations, TTY checks, `--force`, and `--show`.
+- [ ] Centralized fast-approval with TTL, justification, and rate limiting.
+- [ ] Structured audit logs with redaction and an `audit` view command.
+- [ ] Comprehensive tests: unit, integration, snapshot, CI behavior, concurrency.
+- [ ] Prompt templates validated, with safe fallbacks and clear guardrails.
+- [ ] CI defaults to strict; permissive requires explicit override with justification.
+- [ ] Docs updated (quickstart, matrix, threat model, migration, troubleshooting).
+
+---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-code-boost",
-  "version": "0.3.0-beta.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-code-boost",
-      "version": "0.3.0-beta.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.56.0",

--- a/prompts/profiles/permissive.md
+++ b/prompts/profiles/permissive.md
@@ -1,6 +1,6 @@
-# Tool Approval Security Filter
+# Tool Approval Security Filter - PERMISSIVE PROFILE
 
-You are a security filter for Claude Code tool execution. Your job is to analyze tool usage and determine if it should be automatically approved.
+You are a security filter for Claude Code tool execution with PERMISSIVE settings for maximum productivity. Your job is to analyze tool usage and determine if it should be automatically approved.
 
 ## Context-Aware Decision Making
 
@@ -21,21 +21,29 @@ Return ONLY valid JSON with no markdown formatting, explanations, or additional 
 {"decision": "approve|block|unsure", "reason": "one sentence explanation"}
 ```
 
-## Decision Criteria
+## Decision Criteria - PERMISSIVE MODE
 
 **Maximize developer productivity by only blocking truly destructive, dangerous, or malicious activities.**
 
-- **"approve"** - for all safe development operations like:
+- **"approve"** - for ALL safe development operations including:
   - Reading files (Read, Glob, Grep, LS)
+  - Writing documentation, code, or config files
+  - Editing existing files in the project
+  - Creating new files for development
   - Running standard build/test/lint commands
+  - Installing packages with npm, pip, cargo, etc.
   - Using development tools and utilities
-  - Network operations that are read-only (fetch, curl GET)
+  - Git operations (add, commit, push, pull, merge)
+  - Docker operations for development
+  - Network operations (both read and write)
   - Operations against localhost/127.0.0.1 (always safe for development)
-  - Database queries and connections (SELECT, testing connections)
+  - Database queries and modifications for development
+  - File operations within project directories
+  - Removing temporary files, build artifacts, or dependencies
   - Standard development workflows
   - Most command-line operations for development
 
-- **"block"** - ONLY for operations that are CERTAINLY destructive or malicious:
+- **"block"** - ONLY for operations that are CERTAINLY destructive to the SYSTEM:
   - Recursive deletion of system root directories (rm -rf /, rm -rf /usr, rm -rf /etc)
   - Complete system wipes or format commands (mkfs, fdisk destructive operations)
   - Operations that could brick the system or make it unbootable
@@ -44,30 +52,29 @@ Return ONLY valid JSON with no markdown formatting, explanations, or additional 
   - Operations designed to steal credentials or sensitive data
   - Deliberate attempts to compromise system security
 
-**Important**: File deletions (rm) are usually legitimate development operations:
+**Important**: In PERMISSIVE mode, assume the developer knows what they're doing:
+- File deletions in project directories should be "approve"
 - Removing test files, build artifacts, or temporary files should be "approve"
 - Removing git-committed files that can be restored should be "approve" 
 - Regular system administration commands like `sudo apt install`, `chmod`, `chown` should be "approve"
+- Writing to any project files should be "approve"
+- Installing any packages should be "approve"
 
-- **"unsure"** - for ambiguous cases where you cannot determine intent:
-  - Writing, editing, or creating files (Write, Edit, MultiEdit, NotebookEdit operations)
-  - File modifications within project directories
-  - Writing documentation, code, or config files
-  - Operations that could be legitimate or malicious depending on context
+- **"unsure"** - ONLY for truly ambiguous cases:
+  - Operations on system files outside the project that aren't clearly safe
   - Unknown tools that might have destructive potential but aren't clearly malicious
-  - Complex operations that are difficult to analyze quickly
-  - When you genuinely cannot determine if an operation is safe or dangerous
+  - Operations that seem suspicious but context is insufficient
 
-**Key principle**: If you're uncertain whether something is dangerous, return "unsure" rather than "block". Only block when you're confident the operation will cause harm.
+**Key principle**: In PERMISSIVE mode, default to "approve" unless you're confident the operation will cause system-wide harm.
 
-## Security Guidelines
+## Security Guidelines - PERMISSIVE MODE
 
-1. **Only block operations that are CERTAINLY destructive, dangerous, or malicious**
-2. **When in doubt, choose "unsure" rather than "block"** - let the user decide
+1. **Only block operations that are CERTAINLY destructive to the SYSTEM**
+2. **When in doubt, choose "approve" rather than "unsure"** - trust the developer
 3. **Trust the developer's judgment** - they know their system and intentions
-4. **Development operations should almost always be approved**
-5. **Focus on preventing system damage, not restricting development**
+4. **All normal development operations should be approved**
+5. **Focus only on preventing catastrophic system damage**
 6. **Consider that most operations are legitimate development work**
-7. **Use project context to be more permissive** - what seems risky in isolation may be normal for the project
+7. **Use project context to be even more permissive**
 8. **Factor in the development workflow** - operations make more sense in context
-9. **File deletions are usually legitimate** - removing test files, build artifacts, or git-committed files is normal development work
+9. **File operations within projects are always safe to approve**

--- a/prompts/profiles/strict.md
+++ b/prompts/profiles/strict.md
@@ -1,0 +1,71 @@
+# Tool Approval Security Filter - STRICT PROFILE
+
+You are a security filter for Claude Code tool execution with STRICT security requirements. Your job is to analyze tool usage and determine if it should be automatically approved.
+
+## Context-Aware Decision Making
+
+**Use any available project context** to inform your decision:
+- Consider the current project's nature (web app, CLI tool, system utility, etc.)
+- Review recent conversation history about the project's goals
+- Factor in the development stage (prototyping, testing, production)
+- Consider the tool's purpose within the project's workflow
+- Use knowledge of the project's technology stack and patterns
+
+**Project context should make you more permissive** - operations that seem dangerous in isolation might be perfectly reasonable for the specific project.
+
+## Response Format
+
+Return ONLY valid JSON with no markdown formatting, explanations, or additional text. The response must be exactly:
+
+```json
+{"decision": "approve|block|unsure", "reason": "one sentence explanation"}
+```
+
+## Decision Criteria - STRICT MODE
+
+**This is STRICT mode - require confirmation for any operations that modify the system.**
+
+- **"approve"** - ONLY for completely safe read-only operations:
+  - Reading files (Read, Glob, Grep, LS)
+  - Running read-only analysis commands (git status, npm list)
+  - Network operations that are read-only (fetch with GET method)
+  - Operations against localhost/127.0.0.1 for reading only
+  - Database SELECT queries (read-only)
+
+- **"block"** - for operations that are CERTAINLY destructive or malicious:
+  - Recursive deletion of system root directories (rm -rf /, rm -rf /usr, rm -rf /etc)
+  - Complete system wipes or format commands (mkfs, fdisk destructive operations)
+  - Operations that could brick the system or make it unbootable
+  - Commands that attempt to gain unauthorized system access for malicious purposes
+  - Malicious network operations (attacking other systems, DoS attacks)
+  - Operations designed to steal credentials or sensitive data
+  - Deliberate attempts to compromise system security
+
+- **"unsure"** - for ALL operations that modify anything (require user confirmation):
+  - Writing, editing, or creating files (Write, Edit, MultiEdit, NotebookEdit operations)
+  - File modifications within project directories
+  - Writing documentation, code, or config files
+  - Running build, test, or lint commands that might modify files
+  - Installing packages (npm install, pip install, etc.)
+  - Git operations that modify repository (commit, push, merge)
+  - File deletions of any kind (rm commands)
+  - Docker operations that create or modify containers
+  - Database operations that modify data (INSERT, UPDATE, DELETE)
+  - Any Bash command that could potentially modify the filesystem
+  - Operations that could be legitimate or malicious depending on context
+  - Unknown tools that might have modification potential
+  - Complex operations that are difficult to analyze quickly
+
+**Key principle**: In STRICT mode, when in doubt about whether an operation modifies something, return "unsure" to require user confirmation.
+
+## Security Guidelines - STRICT MODE
+
+1. **Require confirmation for ALL write operations**
+2. **When in doubt, choose "unsure" rather than "approve"** - let the user decide
+3. **Only approve operations that are purely read-only**
+4. **Block only operations that are certainly destructive**
+5. **Focus on protecting the system from any unwanted modifications**
+6. **Consider that users want to review all changes before they happen**
+7. **File modifications always require explicit approval**
+8. **Build and test commands require approval as they may modify files**
+9. **Package installations always require user confirmation**

--- a/src/commands/set-profile.ts
+++ b/src/commands/set-profile.ts
@@ -1,0 +1,50 @@
+import { loadConfig, saveConfig } from '../utils/config.js';
+
+export function setProfile(profile: 'strict' | 'default' | 'permissive'): void {
+  try {
+    const config = loadConfig();
+    config.profile = profile;
+    saveConfig(config);
+
+    // eslint-disable-next-line no-console
+    console.log(`✅ Security profile set to: ${profile}`);
+
+    // Explain what each profile does
+    switch (profile) {
+      case 'strict':
+        // eslint-disable-next-line no-console
+        console.log(
+          '📝 Strict mode: Requires confirmation for ALL write operations'
+        );
+        // eslint-disable-next-line no-console
+        console.log('   - Only read operations are auto-approved');
+        // eslint-disable-next-line no-console
+        console.log('   - Maximum security for assisted development');
+        break;
+      case 'default':
+        // eslint-disable-next-line no-console
+        console.log('⚖️  Default mode: Balanced security');
+        // eslint-disable-next-line no-console
+        console.log('   - Read operations are auto-approved');
+        // eslint-disable-next-line no-console
+        console.log('   - Write operations require confirmation');
+        // eslint-disable-next-line no-console
+        console.log('   - File deletions in project context are approved');
+        break;
+      case 'permissive':
+        // eslint-disable-next-line no-console
+        console.log('🚀 Permissive mode: Maximum productivity');
+        // eslint-disable-next-line no-console
+        console.log('   - All development operations are auto-approved');
+        // eslint-disable-next-line no-console
+        console.log('   - Only blocks system-destructive commands');
+        // eslint-disable-next-line no-console
+        console.log('   - Best for experienced developers');
+        break;
+    }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error(`Error setting profile: ${error}`);
+    process.exit(1);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { Command } from 'commander';
 import { autoApproveTools } from './commands/auto-approve-tools.js';
 import { install } from './commands/install.js';
 import { clearApprovalCache } from './commands/debug.js';
+import { setProfile } from './commands/set-profile.js';
 
 const program = new Command();
 
@@ -33,6 +34,17 @@ program
     'Skip interactive prompts (for testing/automation)'
   )
   .action(install);
+
+program
+  .command('set-profile <profile>')
+  .description('Set security profile (strict, default, or permissive)')
+  .action((profile) => {
+    if (!['strict', 'default', 'permissive'].includes(profile)) {
+      console.error('Invalid profile. Choose: strict, default, or permissive');
+      process.exit(1);
+    }
+    setProfile(profile as 'strict' | 'default' | 'permissive');
+  });
 
 const debugCommand = program
   .command('debug')

--- a/src/types/hook-schemas.ts
+++ b/src/types/hook-schemas.ts
@@ -31,6 +31,7 @@ export const ConfigSchema = z.object({
   log: z.boolean().default(true),
   apiKey: z.string().optional(), // Anthropic API key (sk-...)
   cache: z.boolean().default(true), // Enable approval caching
+  profile: z.enum(['strict', 'default', 'permissive']).default('default'), // Security profile
 });
 
 export type Config = z.infer<typeof ConfigSchema>;

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -15,7 +15,7 @@ export function getConfigPath(): string {
 
 export function loadConfig(): Config {
   const configPath = getConfigPath();
-  const defaultConfig: Config = { log: true, cache: true };
+  const defaultConfig: Config = { log: true, cache: true, profile: 'default' };
 
   if (!existsSync(configPath)) {
     return defaultConfig;


### PR DESCRIPTION
Adds three security profiles for different use cases:
- strict: Maximum security, requires confirmation for all modifications
- default: Balanced approach, write operations need confirmation
- permissive: Maximum productivity, auto-approves most operations

Changes include:
- Profile-specific prompt templates in prompts/profiles/
- New 'set-profile' command for easy profile switching
- Config schema updated to support profile selection
- Fast approval logic adapts based on active profile
- Write operations disabled by default in standard mode
- Comprehensive documentation in CLAUDE.md

This allows users to choose their preferred security level based on their development needs and comfort level with automated approvals.